### PR TITLE
Parameter expansion

### DIFF
--- a/src/cmd_execute.c
+++ b/src/cmd_execute.c
@@ -6,7 +6,7 @@
 /*   By: pclaus <pclaus@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/31 22:08:47 by efret             #+#    #+#             */
-/*   Updated: 2024/07/11 12:25:19 by efret            ###   ########.fr       */
+/*   Updated: 2024/07/11 16:56:54 by pclaus           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,7 +92,7 @@ void	read_here_doc(t_minishell *shell, int pipe_fd[2], t_redir *redir, bool expa
 		if (exact_match(line, redir->str))
 			break ;
 		if (expand)
-			expand_double_quotes(&line, shell);
+			process_token(&line, shell);
 		write(pipe_fd[PIPE_W], line, ft_strlen(line));
 		write(pipe_fd[PIPE_W], "\n", 1);
 		free(line);

--- a/src/parameter_expansion.c
+++ b/src/parameter_expansion.c
@@ -6,7 +6,7 @@
 /*   By: pclaus <pclaus@student.s19.be>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/08 17:27:03 by pclaus            #+#    #+#             */
-/*   Updated: 2024/07/11 18:28:25 by pclaus           ###   ########.fr       */
+/*   Updated: 2024/07/11 18:35:10 by pclaus           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,7 +83,7 @@ static char	*get_env_value(t_var *env, char *name)
 		trimmed_name = ft_strtrim(trimmed_name, "}");
 	}
 	node = env_search_name(env, trimmed_name);
-	if (node)
+	if (node && node->value)
 		return (node->value);
 	return ("");
 }

--- a/src/parameter_expansion.c
+++ b/src/parameter_expansion.c
@@ -6,7 +6,7 @@
 /*   By: pclaus <pclaus@student.s19.be>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/08 17:27:03 by pclaus            #+#    #+#             */
-/*   Updated: 2024/07/11 18:16:35 by pclaus           ###   ########.fr       */
+/*   Updated: 2024/07/11 18:28:25 by pclaus           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -133,7 +133,8 @@ void	expand_parameters(t_token **token, t_minishell *shell)
 	iter = *token;
 	while (iter)
 	{
-		process_token(&iter->str, shell);
+		if (!(iter->tag == SINGLE_Q))
+			process_token(&iter->str, shell);
 		if (iter->next)
 			iter = iter->next;
 		else


### PR DESCRIPTION
Fixed several issues:
- small leak in get_expanded_string
- $? expands to the previous exit code within a double-quoted string
- single quotes don't expand anymore
- expanding a empty variable prints empty string instead of resulting in a segfault